### PR TITLE
Stop constructing Timedeltas the way numpy 2.5 deprecates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,7 +156,11 @@ This release is a redesign; the public API is not compatible with 0.3.x.
 * Tests run fully offline against captured NCEI access api payloads,
   with a python/os matrix workflow, tox environments, ruff lint, and a
   97% coverage floor.
-
+* Timedeltas are constructed with an explicit unit. pandas builds a
+  bare numpy timedelta64 from its keyword and string constructor forms,
+  which numpy 2.5 deprecates; under ``filterwarnings = ["error"]`` that
+  failed every coarser- and finer-than-hourly resample path. pandas 3.0
+  fixes it upstream, so this only affects pandas 2.x.
 0.3.29
 ------
 

--- a/eeweather/sources/pipeline.py
+++ b/eeweather/sources/pipeline.py
@@ -233,7 +233,7 @@ def resample_by_vocabulary(df, offset):
     accumulations evenly, never crossing a missing hour.
     """
     if isinstance(offset, pd.tseries.offsets.Tick) and (
-        pd.Timedelta(offset) < pd.Timedelta(hours=1)
+        pd.Timedelta(offset) < pd.Timedelta(1, unit="h")
     ):
         return _upsample(df, offset)
 
@@ -261,12 +261,12 @@ def _upsample(df, offset):
     """Hourly values at a finer frequency; the offset must divide the
     hour evenly."""
     step = pd.Timedelta(offset)
-    if pd.Timedelta(hours=1) % step != pd.Timedelta(0):
+    if pd.Timedelta(1, unit="h") % step != pd.Timedelta(0):
         raise ValueError(
             "A sub-hourly frequency must divide the hour evenly,"
             " got: {}".format(offset.freqstr)
         )
-    slots = int(pd.Timedelta(hours=1) / step)
+    slots = int(pd.Timedelta(1, unit="h") / step)
 
     up = df.resample(offset).asfreq()
     columns = {}


### PR DESCRIPTION
### Your checklist for this pull request

*    Pulling a fix branch (`fix/pandas-numpy-timedelta-warning`) against `power-source`.
*    Tests pass with coverage up: 451 passed, 1 skipped — up from 441 passed with **10 failed** on `power-source`, which this fixes. `ruff check` clean.
*    CHANGELOG.md updated under the "Development" section.
*    Code style: ruff.
*    No new public API; no docstring or docs changes needed.
*    All commits carry the DCO `Signed-off-by` trailer.
*    Parts of this change were drafted with an AI assistant; every commit records it in a `Co-Authored-By` trailer. The tool's terms impose no conditions inconsistent with the project's licence or the Open Source Definition, and the output does not incorporate third-party code.

### Description

Ten tests fail on `power-source` under pandas 2.x with numpy 2.5, every one in the coarser- or finer-than-hourly resample path, every one the same `DeprecationWarning` that `filterwarnings = ["error"]` turns into a failure:

```
The 'generic' unit for NumPy timedelta is deprecated, and will raise an
error in the future. This includes implicit conversion of bare integers
```

In practice `frequency="D"` does not work on this branch.

The warning is not raised by anything unusual in this code. It comes from pandas' own constructor: given keyword or string arguments it builds a bare `np.timedelta64` with no unit, which numpy 2.5 deprecates. Measured across the range `pyproject.toml` declares (`pandas>=2.2`):

| | pandas 2.2.3 | pandas 3.0.5 |
|---|---|---|
| `pd.Timedelta(hours=1)` | warns | clean |
| `pd.Timedelta("1h")` | warns | clean |
| `pd.Timedelta(1, unit="h")` | clean | clean |

So the problem is confined to pandas 2.x — 3.0 fixes it upstream — and the explicit-unit spelling is clean at both ends of the supported range. Three call sites, all `pd.Timedelta(hours=1)` in `sources/pipeline.py`.

Bumping the floor to `pandas>=3.0` would let the more readable keyword form stay, but dropping 2.x support to avoid three characters seemed the wrong trade.
