### PR TITLE
Label how much of a value was interpolated rather than observed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,7 +156,14 @@ This release is a redesign; the public API is not compatible with 0.3.x.
 * Tests run fully offline against captured NCEI access api payloads,
   with a python/os matrix workflow, tox environments, ruff lint, and a
   97% coverage floor.
-
+* ``load_data(imputation=True)`` returns a
+  ``<variable>_imputed_fraction`` companion for each point-in-time
+  variable: 1.0 for an hour nothing was reported for, 0.0 for one that
+  was, NaN where the value itself is NaN. Gap interpolation is otherwise
+  invisible in the returned frame — it invents hours and shifts the value
+  of hours that were observed — so a caller with a rule about missing data
+  had no way to apply it. Outside the vocabulary, so it averages to the
+  fabricated fraction at coarser frequencies. Off by default.
 0.3.29
 ------
 

--- a/eeweather/location.py
+++ b/eeweather/location.py
@@ -11,6 +11,7 @@ from .registry.zones import zones_at
 from .sources import StationSource
 from .sources.engine import known_source_names, resolve_source, _route
 from .sources.pipeline import validate_requested
+from .sources.vocabulary import with_imputed_fractions
 from .sources.matching import rank_stations
 
 
@@ -284,6 +285,8 @@ class WeatherLocation(object):
             variables = ("temperature",)
         groups, requested = _route(variables, self.sources)
         validate_requested(requested)
+        if load_kwargs.get("imputation"):
+            requested = with_imputed_fractions(requested)
 
         frames = []
         warnings = []
@@ -304,7 +307,8 @@ class WeatherLocation(object):
             warnings.extend(group_warnings)
             provenance.update(group_provenance)
 
-        df = pd.concat(frames, axis=1)[list(requested)]
+        df = pd.concat(frames, axis=1)
+        df = df.reindex(columns=[c for c in requested if c in df.columns])
         df.attrs["provenance"] = provenance
         self.provenance = provenance
         self._capture_pins(provenance)

--- a/eeweather/sources/engine.py
+++ b/eeweather/sources/engine.py
@@ -44,6 +44,9 @@ from .tmy3 import TMY3Source
 from .vocabulary import (
     aggregation_for,
     all_variables,
+    imputed_fraction_name,
+    is_imputed_fraction,
+    with_imputed_fractions,
     register_variables,
     valid_variables_or_raise,
 )
@@ -198,9 +201,16 @@ def observation_cache_key(source_name, station_id, year):
 def _fetch_year(adapter, station_id, external_id, year, variables):
     """One year of observations resampled to an hourly frame.
 
+    Always produces an imputed-fraction companion for every point-in-time
+    variable; load_year drops the ones the caller did not ask for. They can
+    only be derived here, where the pre-interpolation observations still
+    exist, so they are computed unconditionally and cached with the data.
+
     Raises DataNotAvailableError when the station has no observations at
     all for the year.
     """
+    # companions are produced here, never requested from the source
+    variables = tuple(v for v in variables if not is_imputed_fraction(v))
     raw = adapter.fetch_year(external_id, year, variables)
     if len(raw) == 0:
         raise DataNotAvailableError(adapter.name, station_id=station_id, year=year)
@@ -209,8 +219,10 @@ def _fetch_year(adapter, station_id, external_id, year, variables):
     accumulation = [c for c in raw.columns if aggregation_for(c) == "sum"]
     parts = []
     if point:
+        # counted before interpolation, the only point the distinction exists
+        observed = raw[point].resample("h").count()
         # CalTRACK 2.3.3
-        parts.append(
+        interpolated = (
             raw[point]
             .resample("min")
             .mean()
@@ -218,11 +230,20 @@ def _fetch_year(adapter, station_id, external_id, year, variables):
             .resample("h")
             .mean()
         )
+        parts.append(interpolated)
+        # NaN, not 1.0, where nothing was filled in: missing is not imputed
+        imputed = (observed.reindex(interpolated.index).fillna(0) == 0).astype(float)
+        imputed = imputed.where(interpolated.notna())
+        imputed.columns = [imputed_fraction_name(c) for c in imputed.columns]
+        parts.append(imputed)
     if accumulation:
         # accumulations add up within the hour and are never fabricated
         # by interpolation
         parts.append(raw[accumulation].resample("h").sum(min_count=1))
-    df = pd.concat(parts, axis=1)[list(raw.columns)]
+    ordered = list(raw.columns) + [
+        imputed_fraction_name(c) for c in point
+    ]
+    df = pd.concat(parts, axis=1)[ordered]
 
     return df
 
@@ -230,6 +251,7 @@ def _fetch_year(adapter, station_id, external_id, year, variables):
 def _load_observation_year(
     adapter, station_id, external_id, year, variables,
     read_from_cache, write_to_cache, fetch_from_web,
+    imputation=False,
 ):
     """One year of hourly data for a station, from cache when it covers
     the request.
@@ -238,6 +260,12 @@ def _load_observation_year(
     request and fetching is disabled.
     """
     fetch = functools.partial(_fetch_year, adapter, station_id, external_id, year)
+    # ordinary columns, so the cache and column selection carry them along
+    if imputation:
+        variables = variables + tuple(
+            imputed_fraction_name(v) for v in variables
+            if aggregation_for(v) != "sum"
+        )
     df = load_year(
         observation_cache_key(adapter.name, station_id, year), year, variables, fetch,
         adapter.cacheable, read_from_cache, write_to_cache, fetch_from_web,
@@ -251,6 +279,7 @@ def _load_observation_year(
 def _load_observations(
     adapter, station_id, start, end, variables,
     read_from_cache, write_to_cache, fetch_from_web,
+    imputation=False,
 ):
     """Hourly observations over the requested years; missing years surface
     as warnings, and NaN rows after alignment."""
@@ -281,6 +310,7 @@ def _load_observations(
                 _load_observation_year(
                     adapter, station_id, external_id, year, variables,
                     read_from_cache, write_to_cache, fetch_from_web,
+                    imputation,
                 )
             )
         except DataNotAvailableError:
@@ -299,8 +329,17 @@ def _load_observations(
     if data:
         df = pd.concat(data)
     else:
+        # the same columns a successful load would have produced, so a
+        # caller reading a companion does not have to special-case the
+        # empty result
+        columns = list(variables)
+        if imputation:
+            columns += [
+                imputed_fraction_name(v) for v in variables
+                if aggregation_for(v) != "sum"
+            ]
         df = pd.DataFrame(
-            columns=list(variables),
+            columns=columns,
             index=pd.DatetimeIndex([], tz=timezone.utc),
             dtype=float,
         )
@@ -410,6 +449,7 @@ def load_data(
     write_to_cache: bool = True,
     fetch_from_web: bool = True,
     raise_when_empty: bool | None = None,
+    imputation: bool = False,
 ):
     """Load a station's weather data between two dates (inclusive).
 
@@ -444,6 +484,17 @@ def load_data(
         Whether a request yielding no data at all raises
         DataNotAvailableError; defaults to True for pinned requests and
         False for routed ones (partial coverage never raises either way).
+    imputation : bool
+        Also return, for each point-in-time variable, a
+        ``<variable>_imputed_fraction`` column saying how much of each
+        value was fabricated by gap interpolation rather than observed.
+        At hourly frequency it is 1.0 for an hour nothing was reported
+        for, 0.0 for an hour that was, and NaN wherever the value itself
+        is NaN -- a gap too long to bridge is missing, not imputed. At
+        coarser frequencies it averages to the fraction of the period's
+        hours that were fabricated. Accumulations are never interpolated
+        and get no companion; neither do typical-year (normals) sources,
+        which have no observations to be missing.
 
     Returns
     -------
@@ -478,6 +529,11 @@ def load_data(
         groups, requested = _route(variables, adapters)
         validate_requested(requested)
 
+    if imputation:
+        # from here the companions are ordinary requested columns, so every
+        # selection downstream carries them without knowing they exist
+        requested = with_imputed_fractions(requested)
+
     warnings = []
     frames = []
     provenance = {}
@@ -488,10 +544,16 @@ def load_data(
             loader = _load_normals
         else:
             raise ValueError("Unknown source kind: {}".format(adapter.kind))
-        group_df, group_warnings = loader(
-            adapter, station_id, start, end, tuple(group_variables),
-            read_from_cache, write_to_cache, fetch_from_web,
-        )
+        if adapter.kind == "observations":
+            group_df, group_warnings = loader(
+                adapter, station_id, start, end, tuple(group_variables),
+                read_from_cache, write_to_cache, fetch_from_web, imputation,
+            )
+        else:
+            group_df, group_warnings = loader(
+                adapter, station_id, start, end, tuple(group_variables),
+                read_from_cache, write_to_cache, fetch_from_web,
+            )
         warnings.extend(group_warnings)
         frames.append(group_df)
         provenance[adapter.name] = Provenance(
@@ -503,7 +565,8 @@ def load_data(
             payload={},
         )
 
-    df = pd.concat(frames, axis=1)[list(requested)]
+    df = pd.concat(frames, axis=1)
+    df = df.reindex(columns=[c for c in requested if c in df.columns])
     if offset != pd.tseries.frequencies.to_offset("h"):
         df = resample_by_vocabulary(df, offset)
     df = align_to_range(df, start, end, offset)

--- a/eeweather/sources/vocabulary.py
+++ b/eeweather/sources/vocabulary.py
@@ -171,6 +171,34 @@ VARIABLES = {
 
 RESERVED_SUFFIXES = ("_imputed_fraction", "_is_imputed")
 
+# one of RESERVED_SUFFIXES; the other stays reserved
+IMPUTED_FRACTION_SUFFIX = "_imputed_fraction"
+
+
+def imputed_fraction_name(variable):
+    """The companion column reporting `variable`'s imputed fraction."""
+    return variable + IMPUTED_FRACTION_SUFFIX
+
+
+def with_imputed_fractions(variables):
+    """`variables` plus a companion for each one that can be interpolated.
+
+    Expanded at the routing boundary rather than inside the loader so that
+    every column selection downstream carries the companions without
+    knowing they exist. Accumulations are never gap-interpolated and get
+    none.
+    """
+    return tuple(variables) + tuple(
+        imputed_fraction_name(v) for v in variables
+        if aggregation_for(v) != "sum"
+    )
+
+
+def is_imputed_fraction(column):
+    """Whether a frame column is an imputed-fraction companion."""
+    return column.endswith(IMPUTED_FRACTION_SUFFIX)
+
+
 _registered_variables = {}
 
 

--- a/eeweather/station.py
+++ b/eeweather/station.py
@@ -203,6 +203,7 @@ class WeatherStation(object):
         read_from_cache: bool = True,
         write_to_cache: bool = True,
         fetch_from_web: bool = True,
+        imputation: bool = False,
     ):
         """Load this station's weather data between two dates (inclusive).
 
@@ -236,13 +237,19 @@ class WeatherStation(object):
             Whether or not to write newly loaded data to cache.
         fetch_from_web : bool
             Whether or not to fetch data from the web.
+        imputation : bool
+            Also return a ``<variable>_imputed_fraction`` companion for
+            each point-in-time variable, saying how much of each value
+            was fabricated by gap interpolation rather than observed.
 
         Returns
         -------
         tuple of (pandas.DataFrame, list of EEWeatherWarning)
-            One column per requested variable, indexed over the full
-            requested range at the requested frequency; periods without
-            data are NaN. The frame's ``attrs["provenance"]`` (also
+            One column per requested variable -- plus an
+            imputed-fraction companion per point-in-time variable when
+            ``imputation`` is set -- indexed over the full requested
+            range at the requested frequency; periods without data are
+            NaN. The frame's ``attrs["provenance"]`` (also
             recorded on ``self.provenance``) maps each source used to a
             Provenance record.
         """
@@ -257,6 +264,7 @@ class WeatherStation(object):
             read_from_cache=read_from_cache,
             write_to_cache=write_to_cache,
             fetch_from_web=fetch_from_web,
+            imputation=imputation,
         )
         self.provenance = df.attrs["provenance"]
 

--- a/tests/sources/test_engine.py
+++ b/tests/sources/test_engine.py
@@ -16,6 +16,7 @@ from eeweather.sources.engine import (
     observation_cache_key,
 )
 from eeweather.sources.ghcnh import GHCNhSource
+from eeweather.sources.vocabulary import aggregation_for
 from eeweather.sources.tmy3 import TMY3Source
 
 
@@ -30,8 +31,11 @@ TMY3 = TMY3Source()
 def test_fetch_year(mock_api_transport):
     df = _fetch_year(GHCNH, "USW00093134", "USW00093134", 2007, ("temperature",))
 
-    assert list(df.columns) == ["temperature"]
-    assert df.shape == (8760, 1)
+    # the imputed-fraction companion rides along unconditionally: it can only
+    # be derived here, before interpolation, so it has to be cached with the
+    # data rather than computed on demand
+    assert list(df.columns) == ["temperature", "temperature_imputed_fraction"]
+    assert df.shape == (8760, 2)
     assert df.index[0] == datetime(2007, 1, 1, tzinfo=pytz.UTC)
     assert df.temperature.sum() == pytest.approx(156159.5455, abs=1e-3)
 
@@ -42,8 +46,151 @@ def test_fetch_year_multiple_variables(mock_api_transport):
         ("temperature", "relative_humidity"),
     )
 
-    assert list(df.columns) == ["temperature", "relative_humidity"]
-    assert df.shape == (8760, 2)
+    assert list(df.columns) == [
+        "temperature",
+        "relative_humidity",
+        "temperature_imputed_fraction",
+        "relative_humidity_imputed_fraction",
+    ]
+    assert df.shape == (8760, 4)
+
+
+# imputation labelling
+
+
+class _Observations:
+    """A source serving exactly the observations it is given."""
+
+    name = "fake"
+    cacheable = False
+    kind = "observations"
+    id_namespace = "usaf"
+    variables = ("temperature",)
+
+    def __init__(self, timestamps, values):
+        self.index = pd.to_datetime(timestamps, utc=True)
+        self.values = values
+
+    def fetch_year(self, external_id, year, variables):
+        return pd.DataFrame({"temperature": self.values}, index=self.index)
+
+
+def _labelled(timestamps, values, through):
+    df = _fetch_year(
+        _Observations(timestamps, values), "s", "e", 2020, ("temperature",))
+    return df.loc["2020-01-01 00:00":through]
+
+
+def test_an_observed_hour_is_labelled_observed():
+    window = _labelled(
+        ["2020-01-01 00:00", "2020-01-01 01:00"], [10.0, 12.0],
+        "2020-01-01 01:00")
+
+    assert list(window["temperature_imputed_fraction"]) == [0.0, 0.0]
+
+
+def test_a_fabricated_hour_is_labelled_imputed():
+    """Two unobserved hours between readings are filled completely, and
+    nothing in the value column says so."""
+    window = _labelled(
+        ["2020-01-01 00:00", "2020-01-01 03:00"], [10.0, 40.0],
+        "2020-01-01 03:00")
+
+    assert list(window["temperature_imputed_fraction"]) == [0.0, 1.0, 1.0, 0.0]
+    assert window["temperature"].notna().all()
+
+
+def test_a_gap_too_long_to_bridge_is_missing_not_imputed():
+    """Interpolation reaches one hour either side. Beyond that the value is
+    NaN, and the companion is NaN too -- absent, not fabricated."""
+    window = _labelled(
+        ["2020-01-01 00:00", "2020-01-01 05:00"], [10.0, 60.0],
+        "2020-01-01 05:00")
+    fraction = window["temperature_imputed_fraction"]
+
+    assert list(fraction.isna()) == [False, False, True, True, False, False]
+    assert (fraction.isna() == window["temperature"].isna()).all()
+
+
+def test_the_companion_is_nan_exactly_where_the_value_is():
+    window = _labelled(
+        ["2020-01-01 00:00", "2020-01-01 08:00"], [10.0, 90.0],
+        "2020-01-01 08:00")
+
+    assert (window["temperature"].isna()
+            == window["temperature_imputed_fraction"].isna()).all()
+
+
+def test_the_companion_aggregates_by_mean():
+    """Which is what makes a coarse-frequency value the *fraction* of the
+    period's hours that were fabricated. It works because the companion is
+    outside the vocabulary and aggregation_for averages anything it does not
+    recognise -- so this is the assumption the naming rests on."""
+    assert aggregation_for("temperature_imputed_fraction") == "mean"
+
+
+def test_averaging_the_companion_gives_the_fabricated_fraction():
+    """Averaged over a period, the companion is the share of that period's
+    valued hours that was made up -- which is what makes the name true at
+    every frequency, not only hourly.
+
+    Averaged by slicing rather than resampling: any offset arithmetic trips
+    a pandas DeprecationWarning that this base already fails on
+    (test_load_data_daily and friends fail identically without this change),
+    and that is not this change's to fix.
+    """
+    hourly = _labelled(
+        ["2020-01-01 00:00", "2020-01-01 02:00", "2020-01-01 05:00"],
+        [10.0, 30.0, 60.0],
+        "2020-01-01 05:00")
+    fraction = hourly["temperature_imputed_fraction"]
+
+    # hours 0,1,2 -> observed, fabricated, observed
+    assert fraction.iloc[0:3].mean() == pytest.approx(1 / 3)
+    # hours 3,4,5 -> fabricated, fabricated, observed
+    assert fraction.iloc[3:6].mean() == pytest.approx(2 / 3)
+
+
+def test_an_observed_value_is_altered_by_the_interpolation():
+    """Not a property of the companion, but the reason it is needed: the
+    resample moves hours that *were* observed, so the value column alone
+    cannot tell you what the station actually reported."""
+    hourly = _labelled(
+        ["2020-01-01 00:00", "2020-01-01 02:00"], [10.0, 30.0],
+        "2020-01-01 02:00")
+
+    assert hourly["temperature_imputed_fraction"].iloc[0] == 0.0
+    assert hourly["temperature"].iloc[0] != pytest.approx(10.0)
+
+
+def test_imputation_is_off_by_default(mock_api_transport):
+    df, _ = load_data(
+        "USW00093134",
+        datetime(2007, 1, 1, tzinfo=pytz.UTC),
+        datetime(2007, 1, 2, tzinfo=pytz.UTC),
+    )
+
+    assert list(df.columns) == ["temperature"]
+
+
+def test_imputation_appends_companions_after_the_requested_variables(
+        mock_api_transport):
+    """Purely additive: the requested variables keep their positions, so
+    turning the flag on never moves a column a caller was already reading."""
+    df, _ = load_data(
+        "USW00093134",
+        datetime(2007, 1, 1, tzinfo=pytz.UTC),
+        datetime(2007, 1, 2, tzinfo=pytz.UTC),
+        variables=("temperature", "relative_humidity"),
+        imputation=True,
+    )
+
+    assert list(df.columns) == [
+        "temperature",
+        "relative_humidity",
+        "temperature_imputed_fraction",
+        "relative_humidity_imputed_fraction",
+    ]
 
 
 def test_fetch_year_missing_year_raises(mock_api_transport):
@@ -558,7 +705,7 @@ def test_load_cached_data(mock_api_transport, monkeypatch_key_value_store):
     cached = load_cached_data("USW00093134")
 
     assert cached is not None
-    assert list(cached.columns) == ["temperature"]
+    assert list(cached.columns) == ["temperature", "temperature_imputed_fraction"]
     # the cache holds the full fetched year, not just the requested slice
     assert len(cached) == 8760
 
@@ -633,3 +780,20 @@ def test_load_data_untranslatable_station_warns_once(
     assert df.temperature.isna().all()
     names = [w.qualified_name for w in warnings]
     assert names.count("eeweather.data_not_available") == 1
+
+
+def test_an_empty_result_still_has_the_companion_columns(
+        monkeypatch_key_value_store):
+    """Shape must not depend on whether anything loaded: a caller reading
+    a companion should not have to special-case the empty frame."""
+    df, _ = load_data(
+        "USW00093134",
+        datetime(1800, 1, 1, tzinfo=pytz.UTC),
+        datetime(1800, 1, 2, tzinfo=pytz.UTC),
+        imputation=True,
+        fetch_from_web=False,
+    )
+
+    assert list(df.columns) == ["temperature", "temperature_imputed_fraction"]
+    assert len(df) > 0
+    assert df.isna().all().all()

--- a/tests/sources/test_pipeline.py
+++ b/tests/sources/test_pipeline.py
@@ -82,7 +82,8 @@ def test_serialize_deserialize_hourly_data_round_trip(mock_api_transport):
 
     serialized = serialize_hourly_data(df)
 
-    assert serialized["columns"] == ["temperature"]
+    assert serialized["columns"] == [
+        "temperature", "temperature_imputed_fraction"]
     assert serialized["rows"][0][0] == "2007010100"
     assert len(serialized["rows"]) == len(df)
 
@@ -314,7 +315,12 @@ def test_load_year_variable_superset_refetches(
 
     # the refreshed cache entry now covers both variables
     cached, _, _ = read_cached_year(CACHE_KEY, 2007)
-    assert set(cached.columns) == {"temperature", "wind_speed"}
+    assert set(cached.columns) == {
+        "temperature", "wind_speed",
+        # imputed-fraction companions are produced at fetch and cached
+        # with the data; they can only be derived pre-interpolation
+        "temperature_imputed_fraction", "wind_speed_imputed_fraction",
+    }
 
     # a temperature-only request serves the requested subset from cache
     df3 = _load_2007(("temperature",))
@@ -331,7 +337,12 @@ def test_load_year_refresh_keeps_cached_columns_the_request_omits(
     assert list(df.columns) == ["wind_speed"]
 
     cached, _, _ = read_cached_year(CACHE_KEY, 2007)
-    assert set(cached.columns) == {"temperature", "wind_speed"}
+    assert set(cached.columns) == {
+        "temperature", "wind_speed",
+        # imputed-fraction companions are produced at fetch and cached
+        # with the data; they can only be derived pre-interpolation
+        "temperature_imputed_fraction", "wind_speed_imputed_fraction",
+    }
 
 
 def test_load_year_refresh_of_a_stale_entry_keeps_its_columns(
@@ -349,7 +360,12 @@ def test_load_year_refresh_of_a_stale_entry_keeps_its_columns(
     assert list(df.columns) == ["wind_speed"]
 
     cached, _, fresh = read_cached_year(CACHE_KEY, 2007)
-    assert set(cached.columns) == {"temperature", "wind_speed"}
+    assert set(cached.columns) == {
+        "temperature", "wind_speed",
+        # imputed-fraction companions are produced at fetch and cached
+        # with the data; they can only be derived pre-interpolation
+        "temperature_imputed_fraction", "wind_speed_imputed_fraction",
+    }
     assert fresh is True
 
 

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -866,3 +866,31 @@ def test_to_dict_round_trips_coverage_gated_source_after_load(
     state = location.to_dict()
 
     assert state["pins"] == {"ghcnh": "USW00093134"}
+
+
+def test_imputation_reaches_the_location_entry_point():
+    """WeatherLocation.load_data has its own routing, separate from the
+    engine's. It selected on the requested variables and dropped the
+    companions, so the flag silently did nothing through the entry point
+    the docs call primary. Expanding at the routing boundary means every
+    downstream selection carries them without knowing they exist."""
+    location = WeatherLocation(41.88, -87.62)
+
+    df, _ = location.load_data(
+        datetime(2020, 1, 1, tzinfo=timezone.utc),
+        datetime(2020, 1, 3, tzinfo=timezone.utc),
+        imputation=True,
+    )
+
+    assert list(df.columns) == ["temperature", "temperature_imputed_fraction"]
+
+
+def test_imputation_is_off_by_default_at_the_location_entry_point():
+    location = WeatherLocation(41.88, -87.62)
+
+    df, _ = location.load_data(
+        datetime(2020, 1, 1, tzinfo=timezone.utc),
+        datetime(2020, 1, 3, tzinfo=timezone.utc),
+    )
+
+    assert list(df.columns) == ["temperature"]


### PR DESCRIPTION
### Your checklist for this pull request

*    Pulling a feature branch (`feature/imputation-labelling`) against `power-source`.
*    Tests pass with coverage up: 453 passed (12 new, covering the labelling, the horizon of what interpolation reaches, the column contract, and both entry points), `ruff check` clean. The 10 failures are pre-existing on `power-source` (pandas 2.x with numpy 2.5) and are fixed by #106; they are unrelated to this change.
*    CHANGELOG.md updated under the "Development" section.
*    Code style: ruff.
*    New functions carry numpy-style docstrings; `load_data` and `WeatherStation.load_data` parameter docs updated.
*    All commits carry the DCO `Signed-off-by` trailer.
*    Parts of this change were drafted with an AI assistant; every commit records it in a `Co-Authored-By` trailer. The tool's terms impose no conditions inconsistent with the project's licence or the Open Source Definition, and the output does not incorporate third-party code.

### Description

Adds `load_data(imputation=True)`, which returns a `<variable>_imputed_fraction` companion for each point-in-time variable: `1.0` for an hour nothing was reported for, `0.0` for one that was, and `NaN` wherever the value itself is `NaN` — a gap too long to bridge is missing, not imputed, and the companion says so rather than claiming otherwise. Off by default; returned columns are unchanged when it is.

`_fetch_year` upsamples observations to minutes, interpolates with `limit=60, limit_direction="both"`, and resamples back to hours. What comes out is indistinguishable from a frame where every hour was reported, and it is lossy in two directions at once:

```
observations at 00:00 and 02:00, 10.0 and 30.0 degrees

  00:00   14.92   observed    <- station reported 10.0
  01:00   24.92   fabricated
  02:00   34.92   observed    <- station reported 30.0
```

Hours nothing was reported for are invented, and hours that were reported come back with different values, because the hourly mean is taken over interpolated minutes.

Counting NaNs is the only signal a caller has today, and it is a poor one. Measured bridging for a gap between two observations:

| unobserved hours | 1 | 2 | 3 | 4 | 5 | 6 |
|---|---|---|---|---|---|---|
| fabricated | 1 | 2 | 2 | 2 | 2 | 2 |
| left as NaN | 0 | 0 | 1 | 2 | 3 | 4 |

Every long gap is understated by two hours, and short gaps are invisible however many of them a period contains — a day made entirely of two-hour gaps reports zero missing hours.

Details worth review:

*   The companion names are expanded into the requested variables at the routing boundary rather than threaded through the loaders as a flag. There are two routing implementations — the engine's and `WeatherLocation`'s — and a flag has to be repeated in each, failing silently where it is not. Expanded once, every column selection downstream carries the companions without knowing the feature exists.
*   Companions are appended after the requested variables rather than interleaved, so the flag is purely additive: turning it on never moves a column a caller was already reading. An empty result carries them too, so reading one does not require special-casing a failed load.
*   `_imputed_fraction` is one of the two names `vocabulary.RESERVED_SUFFIXES` has held since the module was written and nothing has ever produced; `_is_imputed` stays reserved.
*   The name stays true at every frequency without special casing: the column is outside the vocabulary, `aggregation_for` averages anything it does not recognise, so a coarser rollup is the fraction of that period's valued hours that was fabricated.
*   `NaN` in the companion falls exactly where `NaN` falls in the value, so `value.notna() & (fraction == 0)` is "actually observed".
*   Accumulations are never gap-interpolated and get no companion. Neither do typical-year sources, which have no observations to be missing.

The one trade-off: companions are computed **unconditionally** and cached with the data, because pre-interpolation observations only exist inside `_fetch_year` and there is no way to answer this later. That widens cached frames by one float column per point-in-time variable, and a cache written before this change refetches the first time a companion is requested. Computing only on request would mean a fresh, complete cache still forces a network round trip, which seemed worse.

The rollup test averages by slicing rather than resampling because any offset arithmetic trips the pre-existing pandas failures noted above, which are not this change's to fix.
